### PR TITLE
[Indexer] try fix no function clause matching 

### DIFF
--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -300,6 +300,20 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
   end
 
   def handle_info(
+        {_ref, {:error, :eaddrnotavail}},
+        %__MODULE__{} = state
+      ) do
+
+    Logger.error(fn ->
+      "Catchup index stream exited because the archive node endpoint is unavailable. Restarting"
+    end)
+
+    send(self(), :catchup_index)
+
+    {:noreply, %__MODULE__{state | task: nil}}
+  end
+
+  def handle_info(
         {_ref, {:error, :econnrefused}},
         %__MODULE__{
           fetcher: %Catchup.Fetcher{
@@ -344,4 +358,15 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
 
     {:noreply, %__MODULE__{state | task: nil}}
   end
+
+  def handle_info(
+        {:DOWN, _ref, :process, _pid, :normal},
+        %__MODULE__{} = state
+      ) do
+
+    Logger.error(fn -> "Catchup index stream exited with normal." end)
+
+    {:noreply, %__MODULE__{state | task: nil}}
+  end
+
 end


### PR DESCRIPTION
### Bug Fixes

try fix [#5727](https://github.com/blockscout/blockscout/issues/5727)

```
2022-06-27T15:06:58.663 fetcher=block_catchup [error] GenServer Indexer.Block.Catchup.BoundIntervalSupervisor terminating
** (FunctionClauseError) no function clause matching in Indexer.Block.Catchup.BoundIntervalSupervisor.handle_info/2
    (indexer 0.1.0) lib/indexer/block/catchup/bound_interval_supervisor.ex:181: Indexer.Block.Catchup.BoundIntervalSupervisor.handle_info({#Reference<0.3744636714.3193241602.148993>, {:error, {:tls_alert, {:handshake_failure, 'TLS client: In state hello received SERVER ALERT: Fatal - Handshake Failure\n'}}}}, %Indexer.Block.Catchup.BoundIntervalSupervisor{bound_interval: %Indexer.BoundInterval{current: 2500, maximum: 25000, minimum: 2500}, fetcher: %Indexer.Block.Catchup.Fetcher{block_fetcher: %Indexer.Block.Fetcher{broadcast: :catchup, callback_module: Indexer.Block.Catchup.Fetcher, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: "...", method_to_url: [eth_getBalance: "...", trace_block: "...", trace_replayTransaction: "..."], http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]], variant: EthereumJSONRPC.Parity], receipts_batch_size: 250, receipts_concurrency: 10}, blocks_batch_size: 1, blocks_concurrency: 1, memory_monitor: Indexer.Memory.Monitor}, memory_monitor: nil, task: %Task{owner: #PID<0.21420.29>, pid: #PID<0.21415.29>, ref: #Reference<0.3744636714.3193241602.148993>}})
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {#Reference<0.3744636714.3193241602.148993>, {:error, {:tls_alert, {:handshake_failure, 'TLS client: In state hello received SERVER ALERT: Fatal - Handshake Failure\n'}}}}
State: %Indexer.Block.Catchup.BoundIntervalSupervisor{bound_interval: %Indexer.BoundInterval{current: 2500, maximum: 25000, minimum: 2500}, fetcher: %Indexer.Block.Catchup.Fetcher{block_fetcher: %Indexer.Block.Fetcher{broadcast: :catchup, callback_module: Indexer.Block.Catchup.Fetcher, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: "...", method_to_url: [eth_getBalance: "...", trace_block: "...", trace_replayTransaction: "..."], http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]], variant: EthereumJSONRPC.Parity], receipts_batch_size: 250, receipts_concurrency: 10}, blocks_batch_size: 1, blocks_concurrency: 1, memory_monitor: Indexer.Memory.Monitor}, memory_monitor: nil, task: %Task{owner: #PID<0.21420.29>, pid: #PID<0.21415.29>, ref: #Reference<0.3744636714.3193241602.148993>}}
```